### PR TITLE
Use notarytool and Apple API key credentials for notarization

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "piggy",
   "productName": "piggy",
-  "version": "0.30.1",
+  "version": "0.31.0",
   "description": "Tooling for mobile developers",
   "license": "MIT",
   "author": {

--- a/app/script/notarize.js
+++ b/app/script/notarize.js
@@ -40,7 +40,7 @@ module.exports = async (context) => {
       appleApiIssuer,
     });
     console.log(`Done notarizing ${appId}`);
-  } catch (error) {
-    console.error(error);
+  } catch {
+    console.error('Failed! Please ensure valid credentials are specified via environment variables.');
   }
 };

--- a/app/script/notarize.js
+++ b/app/script/notarize.js
@@ -7,42 +7,40 @@ const {
 module.exports = async (context) => {
   const { electronPlatformName, appOutDir } = context;
   if (electronPlatformName !== 'darwin') {
-    console.error('You can build MacOS .app only on MacOS.');
+    console.warn('You can build MacOS .app only on MacOS.');
     return;
   }
+
   const appName = context.packager.appInfo.productFilename;
   const appPath = path.join(context.appOutDir, `${appName}.app`);
   if (appPath.includes('/dist/win')) {
-    console.log(`skipping notarization for ${appPath}`);
+    console.warn(`skipping notarization for ${appPath}`);
     return;
   }
 
-  if (
-    !process.env.ASC_EMAIL ||
-    !process.env.ASC_PASSWORD ||
-    !process.env.ASC_PROVIDER
-  ) {
-    console.log(
-      `skipping notarization for ${appName}, required credentials not found.`
-    );
+  const {
+    APPLE_API_KEY: appleApiKey,
+    APPLE_API_KEY_ID: appleApiKeyId,
+    APPLE_API_ISSUER: appleApiIssuer,
+  } = process.env;
+
+  if (!appleApiKey || !appleApiKeyId || !appleApiIssuer) {
+    console.warn('skipping notarization, required credentials not found');
     return;
   }
-
-  console.log(`Notarizing ${appId} (${appPath})`);
 
   try {
+    console.warn(`Notarizing ${appId} (${appPath})`);
     await notarize({
+      tool: 'notarytool',
       appBundleId: appId,
       appPath: `${appOutDir}/${appName}.app`,
-      appleId: process.env.ASC_EMAIL,
-      appleIdPassword: process.env.ASC_PASSWORD,
-      ascProvider: process.env.ASC_PROVIDER,
+      appleApiKey,
+      appleApiKeyId,
+      appleApiIssuer,
     });
-
     console.log(`Done notarizing ${appId}`);
   } catch (error) {
-    console.error(
-      'Failed! Please ensure valid credentials are specified via environment variables.'
-    );
+    console.error(error);
   }
 };


### PR DESCRIPTION
Update Mac app notarization process to use the `notarytool` and Apple Store Connect API key for authentication