### PR TITLE
Add `ServiceProxy` and hooks for registering HTTP handlers

### DIFF
--- a/app/public/server.js
+++ b/app/public/server.js
@@ -30,8 +30,21 @@ app.get('/api/*', (req, res) => {
   const sendResponse = (event, result) => {
     console.log(`server: sending response for /http/get${url} with id=${id}`);
     clearTimeout(timeoutId);
-    res.status(result.statusCode || 200);
-    res.write(JSON.stringify(result.data || {}));
+    const statusCode = result.statusCode || 200;
+    let { data: responseBody, contentType } = result;
+    if (!contentType) {
+      if (_.isObject(responseBody)) {
+        responseBody = JSON.stringify(responseBody);
+        contentType = 'application/json';
+      } else if (_.isString(responseBody)) {
+        responseBody = String(responseBody);
+        contentType = 'text/plain';
+      }
+    }
+    res
+      .type(contentType)
+      .status(statusCode)
+      .write(responseBody || '');
     res.end();
   };
   timeoutId = setTimeout(() => {

--- a/app/public/server.js
+++ b/app/public/server.js
@@ -27,7 +27,7 @@ app.get('/api/*', (req, res) => {
   ipcProxy.emitToRenderer('/http/get', id, data);
   console.log(`server: emitting /http/get for ${url}`);
   let timeoutId;
-  const sendResponse = (event, result) => {
+  const sendResponse = (_event, result) => {
     console.log(`server: sending response for /http/get${url} with id=${id}`);
     clearTimeout(timeoutId);
     const statusCode = result.statusCode || 200;
@@ -51,9 +51,13 @@ app.get('/api/*', (req, res) => {
     console.warn(
       `server: timeout waiting for response for /http/get${url} with id=${id}`
     );
-    res.status(500);
-    res.write(JSON.stringify({ error: 'timeout' }));
-    res.end();
+    sendResponse(
+      {},
+      {
+        statusCode: 500,
+        data: { error: 'timeout' },
+      }
+    );
     ipcProxy.offRenderer(id, sendResponse);
   }, HTTP_REQUEST_TIMEOUT_MS);
   ipcProxy.onceRenderer(id, sendResponse);

--- a/app/src/App/Plugins/Standard/EventLog/DataWrapper.js
+++ b/app/src/App/Plugins/Standard/EventLog/DataWrapper.js
@@ -1,13 +1,14 @@
 import _ from 'lodash';
 import React, { Component } from 'react';
 import getPluginIntegrations from '@plugins/integrations';
+import serverProxy from '@app/ServerProxy';
 import eventFilter from './EventFilter';
 import EventFormatter from './EventFormatter';
 import { FILTER_TYPES } from './EventConstants';
 import { sortByTimestampAndId, formatItemType } from './utils';
 
 const MAX_ITEMS = 1500;
-const EVENT_NAME = '/ws/recv/eventLog/send';
+const EVENT_NAME = '/eventLog/send';
 
 export default function connectData(WrappedComponent) {
   return class extends Component {
@@ -47,11 +48,11 @@ export default function connectData(WrappedComponent) {
     }
 
     componentDidMount() {
-      global.ipc.events.on(EVENT_NAME, this.handleEventLogEvent);
+      serverProxy.onWs(EVENT_NAME, this.handleEventLogEvent);
     }
 
     componentWillUnmount() {
-      global.ipc.events.off(EVENT_NAME, this.handleEventLogEvent);
+      serverProxy.offWs(EVENT_NAME, this.handleEventLogEvent);
     }
 
     handleEventLogEvent = (event, message) => {

--- a/app/src/App/Plugins/Standard/EventLog/DataWrapper.js
+++ b/app/src/App/Plugins/Standard/EventLog/DataWrapper.js
@@ -55,7 +55,7 @@ export default function connectData(WrappedComponent) {
       serverProxy.offWs(EVENT_NAME, this.handleEventLogEvent);
     }
 
-    handleEventLogEvent = (event, message) => {
+    handleEventLogEvent = (message) => {
       const { sessionId } = message;
       const { sessionId: currentSessionId } = this.state;
       if (currentSessionId !== sessionId) {

--- a/app/src/App/Plugins/Standard/Redux/Redux.js
+++ b/app/src/App/Plugins/Standard/Redux/Redux.js
@@ -5,6 +5,7 @@ import { css } from 'aphrodite/no-important';
 import { GlobalHotKeys } from 'react-hotkeys';
 import { faPlus } from '@fortawesome/free-solid-svg-icons';
 import { flatten } from 'flat';
+import serverProxy from '@app/ServerProxy';
 import Button from '@widgets/Button/Button';
 import Modal from '@widgets/Modal/Modal';
 import Input from '@widgets/Input/Input';
@@ -15,7 +16,7 @@ import styles from './ReduxStyles';
 import { ReduxStateSliceItem } from './ReduxStateSliceItem';
 
 const SET_STATE_SUBSCRIPTIONS_PATHS_MESSAGE = '/stateSubscriptions/setPaths';
-const UPDATE_MESSAGE = '/ws/recv/stateSubscriptions/update';
+const UPDATE_MESSAGE = '/stateSubscriptions/update';
 
 const KEY_MAP = {
   NEW_SUBSCRIPTION: 'command+n',
@@ -64,11 +65,11 @@ export default class StateSubscriptions extends PureComponent {
   };
 
   componentDidMount() {
-    global.ipc.events.on(UPDATE_MESSAGE, this.handleUpdateMessage);
+    serverProxy.onWs(UPDATE_MESSAGE, this.handleUpdateMessage);
   }
 
   componentWillUnmount() {
-    global.ipc.events.off(UPDATE_MESSAGE, this.handleUpdateMessage);
+    serverProxy.offWs(UPDATE_MESSAGE, this.handleUpdateMessage);
   }
 
   toggleModal = () =>
@@ -168,15 +169,15 @@ export default class StateSubscriptions extends PureComponent {
     }
 
     const { subscriptions } = this.state;
-    const stateSubscriptionViews = Object.keys(
-      subscriptions
-    ).map((stateSubscriptionKey) => (
-      <ReduxStateSliceItem
-        subscriptions={subscriptions}
-        subscriptionKey={stateSubscriptionKey}
-        handleRemoveSubscription={this.handleRemoveSubscription}
-      />
-    ));
+    const stateSubscriptionViews = Object.keys(subscriptions).map(
+      (stateSubscriptionKey) => (
+        <ReduxStateSliceItem
+          subscriptions={subscriptions}
+          subscriptionKey={stateSubscriptionKey}
+          handleRemoveSubscription={this.handleRemoveSubscription}
+        />
+      )
+    );
 
     return (
       <GlobalHotKeys keyMap={KEY_MAP} handlers={this.keyHandlers}>

--- a/app/src/App/Plugins/Standard/Redux/Redux.js
+++ b/app/src/App/Plugins/Standard/Redux/Redux.js
@@ -39,7 +39,7 @@ export default class StateSubscriptions extends PureComponent {
   }
 
   // Called when a subscription updates
-  handleUpdateMessage = (_event, message) => {
+  handleUpdateMessage = (message) => {
     const { subscriptions } = this.state;
     const updatedSubscriptions = message.data;
     const mergedStateSubscriptions = { ...subscriptions };

--- a/app/src/App/Plugins/Standard/Timeline/DataWrapper.js
+++ b/app/src/App/Plugins/Standard/Timeline/DataWrapper.js
@@ -1,9 +1,10 @@
 import React, { Component } from 'react';
+import serverProxy from '@app/ServerProxy';
 import _ from 'lodash';
 
 const IDLE_TIME_MS = 2000;
 const COLLAPSED_IDLE_DURATION_MS = 200;
-const TIMELINE_UPDATE_MESSAGE = '/ws/recv/timeline/send';
+const TIMELINE_UPDATE_MESSAGE = '/timeline/send';
 
 export const WORK_TYPE = {
   ACTIVE: 'active',
@@ -27,24 +28,23 @@ export default function connectData(WrappedComponent) {
         excludedGroups: new Set(),
         sessionId: null,
       };
-      this.handleTimelineUpdateMessage = this.handleTimelineUpdateMessage.bind(
-        this
-      );
+      this.handleTimelineUpdateMessage =
+        this.handleTimelineUpdateMessage.bind(this);
     }
 
     componentDidMount() {
-      global.ipc.events.on(
+      serverProxy.onWs(
         TIMELINE_UPDATE_MESSAGE,
         this.handleTimelineUpdateMessage
       );
-    };
+    }
 
     componentWillUnmount() {
-      global.ipc.events.off(
+      serverProxy.offWs(
         TIMELINE_UPDATE_MESSAGE,
         this.handleTimelineUpdateMessage
       );
-    };
+    }
 
     handleTimelineUpdateMessage(event, message) {
       const { data: incomingRawData, sessionId } = message;
@@ -381,6 +381,6 @@ export default function connectData(WrappedComponent) {
         clearData: this.clearData,
       };
       return <WrappedComponent ref={this.componentRef} {...wrappedProps} />;
-    };
+    }
   };
 }

--- a/app/src/App/Plugins/Standard/Timeline/DataWrapper.js
+++ b/app/src/App/Plugins/Standard/Timeline/DataWrapper.js
@@ -46,7 +46,7 @@ export default function connectData(WrappedComponent) {
       );
     }
 
-    handleTimelineUpdateMessage(event, message) {
+    handleTimelineUpdateMessage(message) {
       const { data: incomingRawData, sessionId } = message;
       const { sessionId: currentSessionId } = this.state;
       if (sessionId !== currentSessionId) {

--- a/app/src/App/ServerProxy.js
+++ b/app/src/App/ServerProxy.js
@@ -49,7 +49,6 @@ const handleHttpMessage = async (_event, requestId, request) => {
 };
 
 const handleWebSocketMessage = async (_event, request) => {
-  console.log(request);
   const handlers = registry[SERVER_MESSAGE_TYPE.WEBSOCKET][request.name] || [];
   handlers.forEach((h) => h.callback(request));
 };

--- a/app/src/App/ServerProxy.js
+++ b/app/src/App/ServerProxy.js
@@ -24,10 +24,14 @@ const handleHttpMessage = async (_event, requestId, request) => {
     });
     return;
   }
-  const response = await handler.callback(request);
-  const statusCode = response.statusCode || 200;
-  const data = response.data || {};
-  global.ipc.events.emit(requestId, { statusCode, data });
+  let response = await handler.callback(request);
+  if (!response.data) {
+    response = {
+      data: response,
+      statusCode: 200,
+    };
+  }
+  global.ipc.events.emit(requestId, response);
 };
 
 const register = (type, path, callback) => {

--- a/app/src/App/ServerProxy.js
+++ b/app/src/App/ServerProxy.js
@@ -79,7 +79,7 @@ const unregister = (type, path, callback) => {
     }
     delete registry[SERVER_MESSAGE_TYPE.HTTP][sanitizedPath];
   } else if (type === SERVER_MESSAGE_TYPE.WEBSOCKET) {
-    const fullPath = `/ws/recv/${sanitizedPath}`;
+    const fullPath = `/ws/recv${sanitizedPath}`;
     registry[SERVER_MESSAGE_TYPE.WEBSOCKET][sanitizedPath] = _.filter(
       registry[SERVER_MESSAGE_TYPE.WEBSOCKET][sanitizedPath] || [],
       (e) => e.path !== sanitizedPath || e.callback !== callback
@@ -106,4 +106,12 @@ const offHttp = (path, callback) => {
   unregister(SERVER_MESSAGE_TYPE.HTTP, path, callback);
 };
 
-export default { onWs, offWs, onHttp, offHttp };
+const emitWs = (path, data = {}) => {
+  const sanitizedPath = sanitizePath(path);
+  global.ipc.events.emit('/ws/send', {
+    name: sanitizedPath,
+    data,
+  });
+};
+
+export default { emitWs, onWs, offWs, onHttp, offHttp };

--- a/app/src/App/ServerProxy.js
+++ b/app/src/App/ServerProxy.js
@@ -1,0 +1,109 @@
+import _ from 'lodash';
+
+const SERVER_MESSAGE_TYPE = {
+  WEBSOCKET: 'websocket',
+  HTTP: 'http',
+};
+
+const registry = {
+  /* we can have multiple handlers for websocket messages, as they
+  may be informative broadcasts */
+  [SERVER_MESSAGE_TYPE.WEBSOCKET]: {},
+  /* we enforce a single handler for HTTP requests */
+  [SERVER_MESSAGE_TYPE.HTTP]: {},
+};
+
+const sanitizePath = (path) => (path[0] === '/' ? path : `/${path}`);
+
+const handleHttpMessage = async (_event, requestId, request) => {
+  const handler = registry[SERVER_MESSAGE_TYPE.HTTP][request.url];
+  if (!handler) {
+    global.ipc.events.emit(requestId, {
+      statusCode: 404,
+      data: { error: 'no handler found' },
+    });
+    return;
+  }
+  const response = await handler.callback(request);
+  const statusCode = response.statusCode || 200;
+  const data = response.data || {};
+  global.ipc.events.emit(requestId, { statusCode, data });
+};
+
+const register = (type, path, callback) => {
+  const sanitizedPath = sanitizePath(path);
+  if (type === SERVER_MESSAGE_TYPE.WEBSOCKET) {
+    const fullPath = `/ws/recv${sanitizedPath}`;
+    const handlers =
+      registry[SERVER_MESSAGE_TYPE.WEBSOCKET][sanitizedPath] || [];
+    const existing = _.find(
+      handlers,
+      (e) => e.path === sanitizedPath && e.callback === callback
+    );
+    if (existing) {
+      console.error(
+        `${type} message for ${sanitizedPath} already registered with the specified callback`
+      );
+      return;
+    }
+    handlers.push({ path: sanitizedPath, callback });
+    registry[SERVER_MESSAGE_TYPE.WEBSOCKET][sanitizedPath] = handlers;
+    global.ipc.events.on(fullPath, callback);
+  } else if (type === SERVER_MESSAGE_TYPE.HTTP) {
+    if (registry[SERVER_MESSAGE_TYPE.HTTP][sanitizedPath]) {
+      console.error(`${type} message for ${sanitizedPath} already registered.`);
+      return;
+    }
+    registry[SERVER_MESSAGE_TYPE.HTTP][sanitizedPath] = {
+      path: sanitizedPath,
+      callback,
+    };
+  }
+};
+
+const unregister = (type, path, callback) => {
+  const sanitizedPath = sanitizePath(path);
+  if (type === SERVER_MESSAGE_TYPE.HTTP) {
+    const existing = registry[SERVER_MESSAGE_TYPE.HTTP][sanitizedPath];
+    if (!existing) {
+      console.error(
+        `${type} message for ${sanitizedPath} is *NOT* registered.`
+      );
+      return;
+    }
+    if (existing.callback !== callback) {
+      console.error(
+        `${type} message for ${sanitizedPath} is registered, but with a different callback.`
+      );
+      return;
+    }
+    delete registry[SERVER_MESSAGE_TYPE.HTTP][sanitizedPath];
+  } else if (type === SERVER_MESSAGE_TYPE.WEBSOCKET) {
+    const fullPath = `/ws/recv/${sanitizedPath}`;
+    registry[SERVER_MESSAGE_TYPE.WEBSOCKET][sanitizedPath] = _.filter(
+      registry[SERVER_MESSAGE_TYPE.WEBSOCKET][sanitizedPath] || [],
+      (e) => e.path !== sanitizedPath || e.callback !== callback
+    );
+    global.ipc.events.off(fullPath, callback);
+  }
+};
+
+global.ipc.events.on('/http/get', handleHttpMessage);
+
+const onWs = (path, callback) => {
+  register(SERVER_MESSAGE_TYPE.WEBSOCKET, path, callback);
+};
+
+const offWs = (path, callback) => {
+  unregister(SERVER_MESSAGE_TYPE.WEBSOCKET, path, callback);
+};
+
+const onHttp = (path, callback) => {
+  register(SERVER_MESSAGE_TYPE.HTTP, path, callback);
+};
+
+const offHttp = (path, callback) => {
+  unregister(SERVER_MESSAGE_TYPE.HTTP, path, callback);
+};
+
+export default { onWs, offWs, onHttp, offHttp };


### PR DESCRIPTION
# Overview

Updates to improve ergonomics handling `/ws/recv`, and added the ability for plugins to handle http requests via new `/http/get`.

# Details

1. Add new `/http/get` message emitted from the server process to the renderer process, allowing plugins to process incoming HTTP requests and generate responses. 
2. Added new `ServiceProxy` module to the renderer client. This module does the following:
    * Acts as a central registry for plugins to register for `/ws/recv` and `/http/get` callbacks with an explicit, ergonomic API.
    * Ensures semantics are followed properly: only one handler for `/http/get/*` endpoints, but multiple handlers for `/ws/recv/*` messages. Guards against duplicative registrations or erroneous de-registrations.